### PR TITLE
Optimize Ajv benchmark

### DIFF
--- a/suites/simple.js
+++ b/suites/simple.js
@@ -119,9 +119,11 @@ const obj = {
 			"age"
 		]
 	};
+	
+	var validate = ajv.compile(constraints);
 
 	bench.add("ajv", () => {
-		return ajv.validate(constraints, obj);
+		return validate(obj);
 	});
 }());
 

--- a/suites/simple.js
+++ b/suites/simple.js
@@ -120,7 +120,7 @@ const obj = {
 		]
 	};
 	
-	var validate = ajv.compile(constraints);
+	const validate = ajv.compile(constraints);
 
 	bench.add("ajv", () => {
 		return validate(obj);


### PR DESCRIPTION
The current benchmark is testing Ajv without schema pre-compilation. If the schema is compiled, Ajv actually outperforms all of the validators included in the benchmark. cc @epoberezkin


```
Platform info:
==============
   Darwin 17.5.0 x64
   Node.JS: 9.3.0
   V8: 6.2.414.46-node.15
   Intel(R) Core(TM) i7-3615QM CPU @ 2.30GHz × 8

Suite: Benchmark #1 - Simple object
✔ validator.js x 293,972 ops/sec ±1.18% (85 runs sampled)
✔ validate.js x 64,491 ops/sec ±1.99% (82 runs sampled)
✔ validatorjs x 97,679 ops/sec ±2.07% (83 runs sampled)
✔ joi x 36,459 ops/sec ±1.84% (84 runs sampled)
✔ ajv x 2,510,333 ops/sec ±1.08% (90 runs sampled)
✔ mschema x 370,614 ops/sec ±0.81% (83 runs sampled)
✔ parambulator x 7,325 ops/sec ±3.27% (81 runs sampled)
✔ fastest-validator x 2,298,104 ops/sec ±1.69% (86 runs sampled)

   validator.js             -88.29%    (293,972 ops/sec)
   validate.js              -97.43%     (64,491 ops/sec)
   validatorjs              -96.11%     (97,679 ops/sec)
   joi                            -98.55%    (36,459 ops/sec)
   ajv                            0.00%       (2,510,333 ops/sec)
   mschema               -85.24%    (370,614 ops/sec)
   parambulator         -99.71%     (7,325 ops/sec)
   fastest-validator    -8.45%      (2,298,104 ops/sec)
```